### PR TITLE
make check_key_press function unsafe

### DIFF
--- a/botw-freecam/src/dolly.rs
+++ b/botw-freecam/src/dolly.rs
@@ -100,7 +100,7 @@ impl Interpolate for Vec<CameraSnapshot> {
         'outer: loop {
             let mut t = 0.;
             while t < 1. {
-                if check_key_press(winuser::VK_F8) {
+                if unsafe { check_key_press(winuser::VK_F8) } {
                     break 'outer;
                 }
 

--- a/botw-freecam/src/lib.rs
+++ b/botw-freecam/src/lib.rs
@@ -218,7 +218,7 @@ fn patch(_lib: LPVOID) -> Result<(), Box<dyn std::error::Error>> {
         handle_keyboard(&mut input);
         input.sanitize();
 
-        if input.deattach || check_key_press(winuser::VK_HOME) {
+        if input.deattach || unsafe { check_key_press(winuser::VK_HOME) } {
             info!("Exiting");
             break;
         }
@@ -270,32 +270,32 @@ fn patch(_lib: LPVOID) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
 
-            if check_key_press(winuser::VK_F9) {
+            if unsafe { check_key_press(winuser::VK_F9) } {
                 let cs = CameraSnapshot::new(gc);
                 info!("Point added to interpolation: {:?}", cs);
                 points.push(cs);
                 std::thread::sleep(std::time::Duration::from_millis(400));
             }
 
-            if check_key_press(winuser::VK_F11) {
+            if unsafe { check_key_press(winuser::VK_F11) }{
                 info!("Sequence cleaned!");
                 points.clear();
                 std::thread::sleep(std::time::Duration::from_millis(400));
             }
 
-            if check_key_press(winuser::VK_F10) & (points.len() > 1) {
+            if unsafe { check_key_press(winuser::VK_F10)} & (points.len() > 1) {
                 let dur = std::time::Duration::from_secs_f32(input.dolly_duration);
                 points.interpolate(gc, dur, false);
                 std::thread::sleep(std::time::Duration::from_millis(500));
             }
 
-            if check_key_press(Keys::L as _) & (points.len() > 1) {
+            if unsafe { check_key_press(Keys::L as _)} & (points.len() > 1) {
                 let dur = std::time::Duration::from_secs_f32(input.dolly_duration);
                 points.interpolate(gc, dur, true);
                 std::thread::sleep(std::time::Duration::from_millis(500));
             }
 
-            if check_key_press(winuser::VK_F7) {
+            if unsafe { check_key_press(winuser::VK_F7) }{
                 input.unlock_character = !input.unlock_character;
                 if input.unlock_character {
                     nops.last_mut().unwrap().remove_injection();

--- a/botw-freecam/src/utils.rs
+++ b/botw-freecam/src/utils.rs
@@ -46,7 +46,7 @@ pub enum Keys {
     A = 0x41, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
 }
 
-pub fn check_key_press(key: i32) -> bool {
+pub unsafe fn check_key_press(key: i32) -> bool {
     (unsafe { winuser::GetAsyncKeyState(key) } as u32) & 0x8000 != 0
 }
 
@@ -183,11 +183,11 @@ pub fn handle_keyboard(input: &mut Input) {
         }
     }
 
-    if check_key_press(Keys::P as _) {
+    if unsafe { check_key_press(Keys::P as _) }{
         input.dolly_duration += input.dolly_increment;
         input.dolly_increment *= 1.01;
         println!("Duration: {}", input.dolly_duration);
-    } else if check_key_press(Keys::O as _) {
+    } else if unsafe { check_key_press(Keys::O as _) }{
         input.dolly_duration -= input.dolly_increment;
         input.dolly_increment *= 1.01;
         println!("Duration: {}", input.dolly_duration);
@@ -195,13 +195,13 @@ pub fn handle_keyboard(input: &mut Input) {
         input.dolly_increment = 0.01
     }
 
-    if check_key_press(winuser::VK_LSHIFT) {
+    if unsafe { check_key_press(winuser::VK_LSHIFT) }{
         input.delta_pos.0 *= 8.;
         input.delta_pos.1 *= 8.;
         input.delta_altitude *= 8.;
     }
 
-    if check_key_press(winuser::VK_TAB) {
+    if unsafe { check_key_press(winuser::VK_TAB) }{
         input.delta_pos.0 *= 0.2;
         input.delta_pos.1 *= 0.2;
         input.delta_altitude *= 0.2;


### PR DESCRIPTION
https://github.com/etra0/botw-freecam/blob/5129e21902336ae8555cdcae231a15655201a249/botw-freecam/src/utils.rs#L49-L51
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.